### PR TITLE
fix(docker): do not use makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,11 @@ FROM golang:1.18.0-bullseye AS build
 
 WORKDIR /app
 
-COPY Makefile ./
-COPY go.mod ./
-COPY go.sum ./
-RUN make go-dep
+COPY go.mod go.sum ./
+RUN go mod download
 
 COPY . ./
-RUN make build
+RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o konfig main.go
 
 FROM debian:bullseye-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN CGO_ENABLED=0 go build -a -installsuffix cgo -o konfig main.go
 FROM debian:bullseye-slim
 
 WORKDIR /
+
+RUN apt-get update && apt-get -y upgrade && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/konfig /konfig
-USER nonroot:nonroot
 ENTRYPOINT ["/konfig"]


### PR DESCRIPTION
Fix docker file to not use makefile.

Error can be seen at https://app.circleci.com/pipelines/github/alexfalkowski/konfig/189/workflows/fbc04b66-15ba-4107-ad6e-0013fac7f8cd/jobs/195