### PR TITLE
build: remove docker lint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ proto-lint:
 	make -C api lint
 
 # Lint all the code
-lint: go-lint ruby-lint docker-lint proto-lint proto-breaking
+lint: go-lint ruby-lint proto-lint proto-breaking
 
 # Format proto
 proto-format:


### PR DESCRIPTION
```
make[1]: Leaving directory '/home/circleci/project/test'
hadolint Dockerfile
/usr/local/bin/hadolint: 1: Syntax error: redirection unexpected
make: *** [Makefile:45: docker-lint] Error 2

Exited with code exit status 2

```